### PR TITLE
Add 'env' property support to configuration.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,9 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.pattern = "test/*_test.rb"
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/*_test.rb"]
 end
+
+task :default => :test

--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -20,6 +20,7 @@ class Pups::Config
   def initialize(config)
     @config = config
     validate!(@config)
+    @config["env"]&.each {|k,v| ENV[k] = v}
     @params = @config["params"]
     @params ||= {}
     ENV.each do |k,v|

--- a/pups.gemspec
+++ b/pups.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "guard"

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -10,16 +10,33 @@ module Pups
       assert_equal("world", config.params["$ENV_HELLO"])
     end
 
+    def test_env_param
+      ENV["FOO"] = "BAR"
+      config = <<YAML
+env:
+  BAR: baz
+  hello: WORLD
+YAML
+
+      config = Config.new(YAML.load(config))
+      assert_equal("BAR", config.params["$ENV_FOO"])
+      assert_equal("baz", config.params["$ENV_BAR"])
+      assert_equal("WORLD", config.params["$ENV_hello"])
+    end
+
     def test_integration
 
       f = Tempfile.new("test")
       f.close
 
       config = <<YAML
+env:
+  PLANET: world
 params:
   run: #{f.path}
+  greeting: hello
 run:
-  - exec: echo hello world >> #{f.path}
+  - exec: echo $greeting $PLANET >> #{f.path}
 YAML
 
       Config.new(YAML.load(config)).run

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
 require 'pups'
+require 'minitest/autorun'
 require 'minitest/pride'
-
-


### PR DESCRIPTION
Variables specified under the `env` property in the root of the yaml
configuration file will now be set in the pups environment during the
initialization process. Any existing environment variables are
overwritten by matching variables specified in the config `env` property.

The integration test was updated to exercise the params and env
codepath as this covers the new functionality.