### PR TITLE
Revert "FIX: coerce env to strings"

### DIFF
--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -20,7 +20,6 @@ class Pups::Config
   def initialize(config)
     @config = config
     validate!(@config)
-    @config["env"]&.each {|k,v| ENV[k] = v.to_s}
     @params = @config["params"]
     @params ||= {}
     ENV.each do |k,v|

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -10,35 +10,16 @@ module Pups
       assert_equal("world", config.params["$ENV_HELLO"])
     end
 
-    def test_env_param
-      ENV["FOO"] = "BAR"
-      config = <<YAML
-env:
-  BAR: baz
-  hello: WORLD
-  one: 1
-YAML
-
-      config = Config.new(YAML.load(config))
-      assert_equal("BAR", config.params["$ENV_FOO"])
-      assert_equal("baz", config.params["$ENV_BAR"])
-      assert_equal("WORLD", config.params["$ENV_hello"])
-      assert_equal("1", config.params["$ENV_one"])
-    end
-
     def test_integration
 
       f = Tempfile.new("test")
       f.close
 
       config = <<YAML
-env:
-  PLANET: world
 params:
   run: #{f.path}
-  greeting: hello
 run:
-  - exec: echo $greeting $PLANET >> #{f.path}
+  - exec: echo hello world >> #{f.path}
 YAML
 
       Config.new(YAML.load(config)).run


### PR DESCRIPTION
This reverts commit 262d7eb4f83f9bb2087f1591ee618cbde62ca407 and 8f353a377875f60f4819de7f7e6e1de036b3838f

discourse_docker's launcher, and potentially other systems, manipulate environment variables before applying them to a `docker run` command. At the moment, those tools do not necessarily apply those same manipulations to the YAML file passed to pups.

Specifically, in discourse_docker's launcher, the string `{{config}}` in container labels or environment variables is substituted with the filename of the YAML file. Launcher does not perform this replacement on the file passed to pups. Previously, that was not an issue, because pups didn't use the `env` or `labels` from the file. Now, it causes pups to run its setup using incorrect environment variables.

Reverting this until:
  - We update discourse_docker's launcher so that it performs the replacement on the YAML file passed to pups
  - We come up with a way to avoid breaking old discourse_docker installs (right now they use the latest `master` version of discourse/pups on every build)