### PR TITLE
FEATURE: Support generating docker cli arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage: pups [options] [FILE|--stdin]
         --ignore <elements>          Ignore specific configuration elements, multiple elements can be provided (comma-delimited).
                                      Useful if you want to skip over config in a pups execution.
                                      e.g. `--ignore env,params`.
+        --gen-docker-run-args        Output arguments from the pups configuration for input into a docker run command. All other pups config is ignored.
     -h, --help
 ```
 
@@ -46,6 +47,14 @@ run:
 Running: `pups somefile.yaml` will execute the shell script resulting in a file called "hello" with the contents "hello world".
 
 ### Features
+
+#### Docker run argument generation
+
+The `--gen-docker-run-args` argument is used to make pups output arguments be in the format of `docker run <arguments output>`. Specifically, pups
+will take any `env`, `volume`, `labels`, `links`, and `expose` configuration, and coerce that into the format expected by `docker run`. This can be useful
+when pups is being used to configure an image (e.g. by executing a series of commands) that is then going to be run as a container. That way, the runtime and image
+configuration can be specified within the same yaml files.
+
 
 #### Environment Variables
 

--- a/lib/pups.rb
+++ b/lib/pups.rb
@@ -10,7 +10,7 @@ require 'pups/exec_command'
 require 'pups/merge_command'
 require 'pups/replace_command'
 require 'pups/file_command'
-
+require 'pups/docker'
 require 'pups/runit'
 
 module Pups

--- a/lib/pups/cli.rb
+++ b/lib/pups/cli.rb
@@ -10,6 +10,7 @@ module Pups
         opts.on('--stdin', 'Read input from stdin.')
         opts.on('--quiet', "Don't print any logs.")
         opts.on('--ignore <element(s)>', Array, "Ignore these template configuration elements, multiple elements can be provided (comma-delimited).")
+        opts.on('--gen-docker-run-args', 'Output arguments from the pups configuration for input into a docker run command. All other pups config is ignored.')
         opts.on('-h', '--help') do
           puts opts
           exit
@@ -54,6 +55,11 @@ module Pups
         config = Pups::Config.new(conf, options[:ignore])
       else
         config = Pups::Config.load_file(input_file, options[:ignore])
+      end
+
+      if options[:"gen-docker-run-args"]
+        print config.generate_docker_run_arguments
+        return
       end
 
       config.run

--- a/lib/pups/docker.rb
+++ b/lib/pups/docker.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'shellwords'
+
+class Pups::Docker
+  class << self
+    def generate_env_arguments(config)
+      output = []
+      config&.each do |k, v|
+        if !v.to_s.empty?
+          output << "--env #{k}=#{escape_user_string_literal(v)}"
+        end
+      end
+      normalize_output(output)
+    end
+
+    def generate_link_arguments(config)
+      output = []
+      config&.each do |c|
+        output << "--link #{c['link']['name']}:#{c['link']['alias']}"
+      end
+      normalize_output(output)
+    end
+
+    def generate_expose_arguments(config)
+      output = []
+      config&.each do |c|
+        if c.to_s.include?(":")
+          output << "--publish #{c}"
+        else
+          output << "--expose #{c}"
+        end
+      end
+      normalize_output(output)
+    end
+
+    def generate_volume_arguments(config)
+      output = []
+      config&.each do |c|
+        output << "--volume #{c['volume']['host']}:#{c['volume']['guest']}"
+      end
+      normalize_output(output)
+    end
+
+    def generate_label_arguments(config)
+      output = []
+      config&.each do |k, v|
+        output << "--label #{k}=#{escape_user_string_literal(v)}"
+      end
+      normalize_output(output)
+    end
+
+    private
+    def escape_user_string_literal(str)
+      # We need to escape the following strings as they are more likely to contain
+      # special characters than any of the other config variables on a Linux system:
+      # - the value side of an environment variable
+      # - the value side of a label.
+      if str.to_s.include?(" ")
+        "\"#{Shellwords.escape(str)}\""
+      else
+        Shellwords.escape(str)
+      end
+    end
+
+    def normalize_output(output)
+      if output.empty?
+        ""
+      else
+        output.join(" ")
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -24,10 +24,10 @@ module Pups
       # for testing input
       cf = Tempfile.new('test_config')
       cf.puts <<~YAML
-        params:
-          run: #{f.path}
-        run:
-          - exec: echo hello world >> #{f.path}
+      params:
+        run: #{f.path}
+      run:
+        - exec: echo hello world >> #{f.path}
       YAML
       cf.close
 
@@ -54,6 +54,64 @@ module Pups
 
       Cli.run(["--ignore", "env,params", cf.path])
       assert_equal('repeating and also', File.read(f.path).strip)
+    end
+
+    def test_cli_gen_docker_run_args_ignores_other_config
+      # When generating the docker run arguments it should ignore other template configuration
+      # like 'run' directives.
+
+      # for testing output
+      f = Tempfile.new("test_output")
+      f.close
+
+      # for testing input
+      cf = Tempfile.new("test_config")
+      cf.puts <<~YAML
+      env:
+        foo: 1
+        bar: 5
+        baz: 'hello_{{spam}}'
+      env_template:
+        spam: 'eggs'
+        config: my_app
+      params:
+        run: #{f.path}
+      run:
+        - exec: echo hello world >> #{f.path}
+      expose:
+        - "2222:22"
+        - "127.0.0.1:20080:80"
+        - 5555
+      volumes:
+        - volume:
+            host: /var/discourse/shared
+            guest: /shared
+        - volume:
+            host: /bar
+            guest: /baz
+      links:
+        - link:
+            name: postgres
+            alias: postgres
+        - link:
+            name: foo
+            alias: bar
+      labels:
+        monitor: "true"
+        app_name: "{{config}}_discourse"
+      YAML
+      cf.close
+
+      expected = []
+      expected << "--env foo=1 --env bar=5 --env baz=hello_eggs"
+      expected << "--publish 2222:22 --publish 127.0.0.1:20080:80 --expose 5555"
+      expected << "--volume /var/discourse/shared:/shared --volume /bar:/baz"
+      expected << "--link postgres:postgres --link foo:bar"
+      expected << "--label monitor=true --label app_name=my_app_discourse"
+      expected.sort!
+
+      assert_equal("", File.read(f.path).strip)
+      assert_output(expected.join(" ")) { Cli.run(["--gen-docker-run-args", cf.path]) }
     end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -49,6 +49,27 @@ module Pups
       assert_equal('where are we on pluto?', config.params['$ENV_other'])
     end
 
+    def test_label_with_template
+      ENV["FOO"] = "BAR"
+      config = <<~YAML
+      env:
+        greeting: "{{hello}}, {{planet}}!"
+        one: 1
+        other: "where are we on {{planet}}?"
+      env_template:
+        planet: pluto
+        hello: hola
+        config: various
+      labels:
+        app_name: "{{config}}_discourse"
+      YAML
+      config_hash = YAML.load(config)
+
+      config = Config.new(config_hash)
+      %w[greeting one other].each { |e| ENV.delete(e) }
+      assert_equal("various_discourse", config.config['labels']['app_name'])
+    end
+
     def test_env_with_ENV_templated_variable
       ENV['env_template_config'] = 'my_application'
       config = <<~YAML
@@ -67,6 +88,7 @@ module Pups
       assert_equal('hola, pluto!', config.params['$ENV_greeting'])
       assert_equal('1', config.params['$ENV_one'])
       assert_equal('building my_application', config.params['$ENV_other'])
+      ENV["env_template_config"] = nil
     end
 
     def test_integration
@@ -144,6 +166,52 @@ module Pups
       conf.run
       ENV.delete('PLANET')
       assert_equal('world', File.read(f.path).strip)
+    end
+
+    def test_generate_docker_run_arguments
+      yaml = <<~YAML
+      env:
+        foo: 1
+        bar: 2
+        baz: 'hello_{{spam}}'
+      env_template:
+        spam: 'eggs'
+        config: my_app
+      expose:
+        - "2222:22"
+        - "127.0.0.1:20080:80"
+        - 5555
+      volumes:
+        - volume:
+            host: /var/discourse/shared
+            guest: /shared
+        - volume:
+            host: /bar
+            guest: /baz
+      links:
+        - link:
+            name: postgres
+            alias: postgres
+        - link:
+            name: foo
+            alias: bar
+      labels:
+        monitor: "true"
+        app_name: "{{config}}_discourse"
+      YAML
+
+      config = Config.load_config(yaml)
+      args = config.generate_docker_run_arguments
+
+      expected = []
+      expected << "--env foo=1 --env bar=2 --env baz=hello_eggs"
+      expected << "--publish 2222:22 --publish 127.0.0.1:20080:80 --expose 5555"
+      expected << "--volume /var/discourse/shared:/shared --volume /bar:/baz"
+      expected << "--link postgres:postgres --link foo:bar"
+      expected << "--label monitor=true --label app_name=my_app_discourse"
+      expected.sort!
+
+      assert_equal(expected.join(" "), args)
     end
   end
 end

--- a/test/docker_test.rb
+++ b/test/docker_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'tempfile'
+require 'shellwords'
+
+module Pups
+  class DockerTest < MiniTest::Test
+    def test_gen_env_arguments
+      yaml = <<~YAML
+      env:
+        foo: 1
+        bar: 2
+        baz: 'hello_{{spam}}'
+      env_template:
+        spam: 'eggs'
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
+      args = Docker.generate_env_arguments(config.config["env"])
+      assert_equal("--env foo=1 --env bar=2 --env baz=hello_eggs", args)
+    end
+
+    def test_gen_env_arguments_empty
+      yaml = <<~YAML
+      env:
+        foo: 1
+        bar: 2
+        baz: ''
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
+      args = Docker.generate_env_arguments(config.config["env"])
+      assert_equal("--env foo=1 --env bar=2", args)
+    end
+
+    def test_gen_env_arguments_escaped
+      yaml = <<~YAML
+      env:
+        password: "{{spam}}*`echo`@e$t| = >>$()&list;#"
+      env_template:
+        spam: 'eggs'
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
+      args = Docker.generate_env_arguments(config.config["env"])
+      assert_equal("--env password=\"#{Shellwords.escape('eggs*`echo`@e$t| = >>$()&list;#')}\"", args)
+    end
+
+    def test_gen_env_arguments_quoted_with_a_space
+      yaml = <<~YAML
+      env:
+        a_variable: here is a sentence
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
+      args = Docker.generate_env_arguments(config.config["env"])
+      assert_equal('--env a_variable="here\ is\ a\ sentence"', args)
+    end
+
+    def test_gen_env_arguments_newline
+      pw = <<~PW
+this password is
+  a weird one
+      PW
+
+      yaml = <<~YAML
+      env:
+        password: "#{pw}"
+      env_template:
+        spam: 'eggs'
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
+      args = Docker.generate_env_arguments(config.config["env"])
+      assert_equal('--env password="this\ password\ is\ a\ weird\ one\ "', args)
+    end
+
+    def test_gen_expose_arguments
+      yaml = <<~YAML
+      expose:
+        - "2222:22"
+        - "127.0.0.1:20080:80"
+        - 5555
+      YAML
+
+      config = Config.load_config(yaml)
+      args = Docker.generate_expose_arguments(config.config["expose"])
+      assert_equal("--publish 2222:22 --publish 127.0.0.1:20080:80 --expose 5555", args)
+    end
+
+    def test_gen_volume_arguments
+      yaml = <<~YAML
+      volumes:
+        - volume:
+            host: /var/discourse/shared
+            guest: /shared
+        - volume:
+            host: /bar
+            guest: /baz
+      YAML
+
+      config = Config.load_config(yaml)
+      args = Docker.generate_volume_arguments(config.config["volumes"])
+      assert_equal("--volume /var/discourse/shared:/shared --volume /bar:/baz", args)
+    end
+
+    def test_gen_link_arguments
+      yaml = <<~YAML
+      links:
+        - link:
+            name: postgres
+            alias: postgres
+        - link:
+            name: foo
+            alias: bar
+      YAML
+
+      config = Config.load_config(yaml)
+      args = Docker.generate_link_arguments(config.config["links"])
+      assert_equal("--link postgres:postgres --link foo:bar", args)
+    end
+
+    def test_gen_label_arguments
+      yaml = <<~YAML
+      env_template:
+        config: my_app
+      labels:
+        monitor: "true"
+        app_name: "{{config}}_discourse"
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["labels"])
+      args = Docker.generate_label_arguments(config.config["labels"])
+      assert_equal("--label monitor=true --label app_name=my_app_discourse", args)
+    end
+
+    def test_gen_label_arguments_escaped
+      yaml = <<~YAML
+      labels:
+        app_name: "{{config}}'s_di$course"
+      env_template:
+        config: my_app
+      YAML
+
+      config = Config.load_config(yaml)
+      Config.transform_config_with_templated_vars(config.config['env_template'], config.config["labels"])
+      args = Docker.generate_label_arguments(config.config["labels"])
+      assert_equal("--label app_name=#{Shellwords.escape("my_app's_di$course")}", args)
+    end
+  end
+end


### PR DESCRIPTION
The --gen-docker-env-args argument makes pups process any template
environment variables and generate the command line arguments suitable
for the docker run command. The intention is to expand support for
configuring container runtime into pups such that configuration
templates can be more generally useful.

Also change some exit calls to return to prevent the tests prematurely
exiting.
