### PR TITLE
Add --quiet option to silence logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Or install it yourself as:
 
 pups is a small library that allows you to automate the process of creating Unix images.
 
+```
+Usage: pups [FILE|--stdin]
+        --stdin                      Read input from stdin.
+        --quiet                      Don't print any logs.
+    -h, --help
+```
+
+pups requires input either via a stdin stream or a filename. The entire input is parsed prior to any templating or command execution.
+
 Example:
 
 ```

--- a/lib/pups.rb
+++ b/lib/pups.rb
@@ -26,4 +26,12 @@ module Pups
   def self.log=(logger)
     @logger = logger
   end
+
+  def self.silence
+    if @logger
+      @logger.close
+    end
+
+    @logger = Logger.new(File.open(File::NULL, "w"))
+  end
 end

--- a/lib/pups/cli.rb
+++ b/lib/pups/cli.rb
@@ -4,17 +4,21 @@ require 'optparse'
 
 module Pups
   class Cli
-    def self.parse_args(args)
-      options = {}
-      opt = OptionParser.new do |opts|
+    def self.opts
+      OptionParser.new do |opts|
         opts.banner = 'Usage: pups [FILE|--stdin]'
         opts.on('--stdin', 'Read input from stdin.')
+        opts.on('--quiet', "Don't print any logs.")
         opts.on('-h', '--help') do
           puts opts
           exit
         end
       end
-      opt.parse!(args, into: options)
+    end
+
+    def self.parse_args(args)
+      options = {}
+      opts.parse!(args, into: options)
       options
     end
 
@@ -22,8 +26,12 @@ module Pups
       options = parse_args(args)
       input_file = options[:stdin] ? 'stdin' : args.last
       unless input_file
-        puts opt
+        puts opts.parse!(%w[--help])
         exit
+      end
+
+      if options[:quiet]
+        Pups.silence
       end
 
       Pups.log.info("Reading from #{input_file}")


### PR DESCRIPTION
This prevents any output from pups being printed. Exceptions will still
be output when they occur.

Slightly restructured the cli class so that the options are able to be
parsed separately to the run method so we can print the usage message in
the event of invalid input.