### PR TITLE
Add --ignore option for specific config elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Or install it yourself as:
 pups is a small library that allows you to automate the process of creating Unix images.
 
 ```
-Usage: pups [FILE|--stdin]
+Usage: pups [options] [FILE|--stdin]
         --stdin                      Read input from stdin.
         --quiet                      Don't print any logs.
+        --ignore <elements>          Ignore specific configuration elements, multiple elements can be provided (comma-delimited).
+                                     Useful if you want to skip over config in a pups execution.
+                                     e.g. `--ignore env,params`.
     -h, --help
 ```
 

--- a/lib/pups/cli.rb
+++ b/lib/pups/cli.rb
@@ -4,11 +4,16 @@ require 'optparse'
 
 module Pups
   class Cli
+    attr_accessor :ignored
+
     def self.opts
       OptionParser.new do |opts|
         opts.banner = 'Usage: pups [FILE|--stdin]'
         opts.on('--stdin', 'Read input from stdin.')
         opts.on('--quiet', "Don't print any logs.")
+        opts.on('--ignore <element(s)>', Array, "Ignore these template configuration elements, multiple elements can be provided (comma-delimited).") do |ignore_elements|
+          @ignored = ignore_elements
+        end
         opts.on('-h', '--help') do
           puts opts
           exit
@@ -50,9 +55,9 @@ module Pups
           end
         end
 
-        config = Pups::Config.new(conf)
+        config = Pups::Config.new(conf, @ignored)
       else
-        config = Pups::Config.load_file(input_file)
+        config = Pups::Config.load_file(input_file, @ignored)
       end
 
       config.run

--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -3,7 +3,6 @@
 module Pups
   class Config
     attr_reader :config, :params
-    attr_accessor :ignored
 
     def self.load_file(config_file, ignored = nil)
       Config.new(YAML.load_file(config_file), ignored)

--- a/lib/pups/config.rb
+++ b/lib/pups/config.rb
@@ -3,9 +3,10 @@
 module Pups
   class Config
     attr_reader :config, :params
+    attr_accessor :ignored
 
-    def self.load_file(config_file)
-      new YAML.load_file(config_file)
+    def self.load_file(config_file, ignored = nil)
+      Config.new(YAML.load_file(config_file), ignored)
     rescue Exception
       warn "Failed to parse #{config_file}"
       warn "This is probably a formatting error in #{config_file}"
@@ -13,13 +14,16 @@ module Pups
       raise
     end
 
-    def self.load_config(config)
-      new YAML.safe_load(config)
+    def self.load_config(config, ignored = nil)
+      Config.new(YAML.safe_load(config), ignored)
     end
 
-    def initialize(config)
+    def initialize(config, ignored = nil)
       @config = config
       validate!(@config)
+
+      # remove any ignored config elements prior to any more processing
+      ignored&.each { |e| @config.delete(e) }
 
       # Processing of the environment variables occurs first. This merges environment
       # from the yaml templates and process ENV, and templates any variables found
@@ -113,7 +117,7 @@ module Pups
     end
 
     def run_commands
-      @config['run'].each do |item|
+      @config['run']&.each do |item|
         item.each do |k, v|
           type = case k
                  when 'exec' then Pups::ExecCommand

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -34,5 +34,26 @@ module Pups
       Cli.run([cf.path])
       assert_equal('hello world', File.read(f.path).strip)
     end
+
+    def test_cli_ignore_config_element
+      # for testing output
+      f = Tempfile.new('test_output')
+      f.close
+
+      # for testing input
+      cf = Tempfile.new('test_config')
+      cf.puts <<~YAML
+        env:
+          MY_IGNORED_VAR: a_word
+        params:
+          a_param_var: another_word
+        run:
+          - exec: echo repeating $MY_IGNORED_VAR and also $a_param_var >> #{f.path}
+      YAML
+      cf.close
+
+      Cli.run(["--ignore", "env,params", cf.path])
+      assert_equal('repeating and also', File.read(f.path).strip)
+    end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -21,6 +21,7 @@ module Pups
       YAML
 
       config = Config.new(YAML.safe_load(config))
+      %w[BAR hello one].each { |e| ENV.delete(e) }
       assert_equal('BAR', config.params['$ENV_FOO'])
       assert_equal('baz', config.params['$ENV_BAR'])
       assert_equal('WORLD', config.params['$ENV_hello'])
@@ -41,6 +42,7 @@ module Pups
       config_hash = YAML.safe_load(config)
 
       config = Config.new(config_hash)
+      %w[greeting one other].each { |e| ENV.delete(e) }
       assert_equal('hola, pluto!', config.params['$ENV_greeting'])
       assert_equal('1', config.params['$ENV_one'])
       assert_equal('BAR', config.params['$ENV_FOO'])
@@ -61,6 +63,7 @@ module Pups
       config_hash = YAML.safe_load(config)
 
       config = Config.new(config_hash)
+      %w[greeting one other].each { |e| ENV.delete(e) }
       assert_equal('hola, pluto!', config.params['$ENV_greeting'])
       assert_equal('1', config.params['$ENV_one'])
       assert_equal('building my_application', config.params['$ENV_other'])
@@ -81,6 +84,7 @@ module Pups
       YAML
 
       Config.new(YAML.safe_load(config)).run
+      ENV.delete('PLANET')
       assert_equal('hello world', File.read(f.path).strip)
     ensure
       f.unlink
@@ -104,6 +108,42 @@ module Pups
       config = Config.load_config(yaml).config
       assert_equal({ 'exec' => 1.9 }, config['run'][1])
       assert_equal({ 'exec' => 2.1 }, config['run'][3])
+    end
+
+    def test_ignored_elements
+      f = Tempfile.new('test')
+      f.close
+
+      yaml = <<~YAML
+        env:
+          PLANET: world
+        params:
+          greeting: hello
+        run:
+          - exec: 1
+          - exec:
+              hook: middle
+              cmd: 2
+          - exec: 3
+          - exec: echo $greeting $PLANET >> #{f.path}
+        hooks:
+          after_middle:
+            - exec: 2.1
+          before_middle:
+            - exec: 1.9
+      YAML
+
+      conf = Config.load_config(yaml, %w[hooks params])
+      config = conf.config
+      assert_equal({ 'exec' => 1 }, config['run'][0])
+      assert_equal({ 'exec' => { 'hook' => 'middle', 'cmd' => 2 } }, config['run'][1])
+      assert_equal({ 'exec' => 3 }, config['run'][2])
+      assert_equal({ 'exec' => "echo $greeting $PLANET >> #{f.path}" }, config['run'][3])
+
+      # $greet from params will be an empty var as it was ignored
+      conf.run
+      ENV.delete('PLANET')
+      assert_equal('world', File.read(f.path).strip)
     end
   end
 end


### PR DESCRIPTION
There are use cases where we may want pups to ignore particular
configuration elements at runtime. For example, we may want to skip over
hooks in certain circumstances or define environment variables via the
process at runtime that is already defined in a template.

The follow example demonstrates the usage (note the last log line):

```
$ cat /tmp/test.yml
env:
  MY_VAR: a_word
run:
  - exec: 'echo repeating $MY_VAR'

$ bin/pups --ignore env /tmp/test.yml
I, [2021-06-09T12:03:46.864770 #30369]  INFO -- : Reading from /tmp/test.yml
I, [2021-06-09T12:03:46.865009 #30369]  INFO -- : > echo repeating $MY_VAR
I, [2021-06-09T12:03:46.865824 #30369]  INFO -- : repeating

$ bin/pups /tmp/test.yml
I, [2021-06-09T12:03:50.694739 #30380]  INFO -- : Reading from /tmp/test.yml
I, [2021-06-09T12:03:50.694980 #30380]  INFO -- : > echo repeating $MY_VAR
I, [2021-06-09T12:03:50.695730 #30380]  INFO -- : repeating a_word
```

This will become more useful once the docker run argument generation
functionality is implemented. For example, options like `expose` may
want to be ignored if pups is being used to generate runtime arguments
for more the one container on the same machine (as published port numbers
cannot overlap between containers). Without the `--ignore` lever, all
runtime arguments will be produced all the time which limits usecases.