### PR TITLE
FIX: Remove quotes from escaped strings.

### DIFF
--- a/lib/pups/docker.rb
+++ b/lib/pups/docker.rb
@@ -55,11 +55,7 @@ class Pups::Docker
       # special characters than any of the other config variables on a Linux system:
       # - the value side of an environment variable
       # - the value side of a label.
-      if str.to_s.include?(" ")
-        "\"#{Shellwords.escape(str)}\""
-      else
-        Shellwords.escape(str)
-      end
+      Shellwords.escape(str)
     end
 
     def normalize_output(output)

--- a/test/docker_test.rb
+++ b/test/docker_test.rb
@@ -46,7 +46,7 @@ module Pups
       config = Config.load_config(yaml)
       Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
       args = Docker.generate_env_arguments(config.config["env"])
-      assert_equal("--env password=\"#{Shellwords.escape('eggs*`echo`@e$t| = >>$()&list;#')}\"", args)
+      assert_equal("--env password=#{Shellwords.escape('eggs*`echo`@e$t| = >>$()&list;#')}", args)
     end
 
     def test_gen_env_arguments_quoted_with_a_space
@@ -58,7 +58,7 @@ module Pups
       config = Config.load_config(yaml)
       Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
       args = Docker.generate_env_arguments(config.config["env"])
-      assert_equal('--env a_variable="here\ is\ a\ sentence"', args)
+      assert_equal('--env a_variable=here\ is\ a\ sentence', args)
     end
 
     def test_gen_env_arguments_newline
@@ -77,7 +77,7 @@ this password is
       config = Config.load_config(yaml)
       Config.transform_config_with_templated_vars(config.config['env_template'], config.config["env"])
       args = Docker.generate_env_arguments(config.config["env"])
-      assert_equal('--env password="this\ password\ is\ a\ weird\ one\ "', args)
+      assert_equal('--env password=this\ password\ is\ a\ weird\ one\ ', args)
     end
 
     def test_gen_expose_arguments


### PR DESCRIPTION
When strings have been escaped and contain a space, we don't want to
quote them because the escape character is then treated as a literal.

For example:
```
$ export var1="hello there"
$ export var2="hello\ there"
$ export var3=hello\ there
$ printf "$var1\n$var2\n$var3\n"
hello there
hello\ there
hello there
```